### PR TITLE
cornac 2.3.3 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/powerlaw-feedstock/pr2/3140e0e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/powerlaw-feedstock/pr2/3140e0e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,17 +9,16 @@ source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: 6253d932c7fd65126c3be948134e5d04ecb756f7bf79a081ec0e32dc0dd1df39
   # for upstream tests and their pytest.ini
-  - url: https://github.com/PreferredAI/cornac/archive/refs/tags/v{{ version }}.tar.gz
+  - url: https://github.com/PreferredAI/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
     sha256: 84aaac09e6a198700a8450681c67087cbe3aeaa4b37d3419b323ae09f0d97621
     folder: gh_src
 
 build:
-  # scipy 1.14 is py310+
-  skip: true  # [py<310]
+  skip: true  # [py<39]
   number: 0
   script:
     # build extra modules
-    # https://github.com/PreferredAI/cornac/blob/v2.2.2/setup.py#L328
+    # https://github.com/PreferredAI/cornac/blob/v2.3.3/setup.py#
     - {{ PYTHON }} setup.py build_ext -j{{ CPU_COUNT }}
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   ignore_run_exports:
@@ -28,7 +27,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - llvm-openmp 14.0.6 # [osx and arm64]
@@ -38,11 +36,11 @@ requirements:
     - wheel
     - cython >=0.29.21
     - numpy {{ numpy }}
-    # scipy 1.15.2 has issues with cimports of
-    # scipy.linalg.cython_blas, 1.1[34].* are OK but
-    # - 1.13 does not support py313
-    # - 1.14 does not support py39
-    - scipy 1.14.1
+    # We now require a numpy 2.[01] compatible scipy, ie >=1.13.1=*_1
+    - scipy 1.13.1      # [py<313]
+    - scipy 1.14.1      # [py>=313]
+    # libgomp isn't obvious but you'll get an overdepending error
+    # against cpython .so files without it
     - libgomp 11.2.0    # [linux]
   run:
     - llvm-openmp # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,6 @@ test:
   requires:
     - pip
     - pytest
-    # - pytest-pep8 # unavailable
     - pytest-xdist
     # flask required to test the models (not mentioned
     # in the requirements, but in the tests)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - llvm-openmp 14.0.6 # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cornac" %}
-{% set version = "2.2.2" %}
+{% set version = "2.3.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,45 +7,50 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: ada6d09bd78bbd5b7cd65d2eb8599146e4b8f52ef44651cb25fa6a019d36aa56
+    sha256: 6253d932c7fd65126c3be948134e5d04ecb756f7bf79a081ec0e32dc0dd1df39
   # for upstream tests and their pytest.ini
   - url: https://github.com/PreferredAI/cornac/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 1a4b9839ce6e697155c3ef1b4d85d582a316cef93f24e7157e9275422e021e9b
+    sha256: 84aaac09e6a198700a8450681c67087cbe3aeaa4b37d3419b323ae09f0d97621
     folder: gh_src
 
 build:
-  skip: True  # [py<38 or py>312]
+  # scipy 1.14 is py310+
+  skip: true  # [py<310]
   number: 0
   script:
     # build extra modules
     # https://github.com/PreferredAI/cornac/blob/v2.2.2/setup.py#L328
     - {{ PYTHON }} setup.py build_ext -j{{ CPU_COUNT }}
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  ignore_run_exports:
+    - numpy
+    - libgomp      # [linux]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - llvm-openmp  # [osx and arm64]
   host:
-    - llvm-openmp  # [osx and arm64]
+    - llvm-openmp 14.0.6 # [osx and arm64]
     - python
     - pip
-    - cython
-    - numpy {{ numpy }}
-    # some models cimports scipy.linalg.cython_blas
-    - scipy 1.10.1 # [py<312]
-    - scipy 1.11   # [py==312]
+    - setuptools >=42
     - wheel
-    - setuptools
-    - libgomp  # [linux]
+    - cython >=0.29.21
+    - numpy {{ numpy }}
+    # scipy 1.15.2 has issues with cimports of
+    # scipy.linalg.cython_blas, 1.1[34].* are OK but
+    # - 1.13 does not support py313
+    # - 1.14 does not support py39
+    - scipy 1.14.1
+    - libgomp 11.2.0    # [linux]
   run:
-    - llvm-openmp  # [osx and arm64]
+    - llvm-openmp # [osx and arm64]
     - python
-    # add furher pinnings for numpy and scipy
-    - numpy <2.0.0
-    - scipy <=1.13.1
-    - libgomp  # [linux]
+    # add further pinnings for numpy and scipy
+    - numpy >2.0.0
+    - scipy
+    - libgomp     # [linux]
     - tqdm
     - powerlaw
 
@@ -57,7 +62,7 @@ test:
     - pytest
     # - pytest-pep8 # unavailable
     - pytest-xdist
-    # flask required to test the models (not mentioned 
+    # flask required to test the models (not mentioned
     # in the requirements, but in the tests)
     - flask
   source_files:


### PR DESCRIPTION
cornac 2.3.3 

**Destination channel:** Defaults

### Links

- [PKG-8151]
- dev_url:        https://github.com/PreferredAI/cornac/tree/v2.3.3
- conda_forge:    https://github.com/conda-forge/cornac-feedstock
- pypi:           https://pypi.org/project/cornac/2.3.3
- pypi inspector: https://inspector.pypi.io/project/cornac/2.3.3

### Explanation of changes:

- new version number
- build `py>=39` noting:
  - we can't use the original 1.10.* pinnings as `numpy {{ numpy }}` from `cbc.yaml` implies 2.x
  - `scipy 1.13` which doesn't support `py313`
  - `scipy 1.14+` which doesn't support `py39`


[PKG-8151]: https://anaconda.atlassian.net/browse/PKG-8151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ